### PR TITLE
Minor improvements of esphome config

### DIFF
--- a/config/example-config.yaml
+++ b/config/example-config.yaml
@@ -53,6 +53,9 @@ captive_portal:
 
 ##########################################################################################################################
 
+preferences:
+  flash_write_interval: 3min # Prevents flash writes every 1min in automatic mode
+
 globals:
   - id: current_pwm_level
     type: float

--- a/config/example-config.yaml
+++ b/config/example-config.yaml
@@ -249,7 +249,7 @@ interval:
 
             id(fanhub_pwm).set_level(current_pwm / 100.0);
             id(current_pwm_level) = current_pwm;
-
+            id(fan_pwm_level).publish_state(current_pwm);
             ESP_LOGD("fan_control", "Adjusting PWM: Current=%.2f, Target=%.2f", current_pwm, target);
           }
           


### PR DESCRIPTION
Add 2 little improvements to the esphome configuration:

1. prevent or reduce flash writes to ESP if automatic mode is running by increase the default flash write interval (1min) to 2 x automatic toggle time -> 3min
2. get a smoother UI updates of internal fan_pwm_level changes